### PR TITLE
Explanation step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>owlapi.forgetting</groupId>
@@ -22,9 +22,24 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-    <groupId>net.sourceforge.owlapi</groupId>
-    <artifactId>owlapi-distribution</artifactId>
-    <version>5.1.16</version>
-</dependency>
+      <groupId>net.sourceforge.owlapi</groupId>
+      <artifactId>owlapi-distribution</artifactId>
+      <version>5.1.16</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-nop</artifactId>
+      <version>1.7.25</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.galigator.openllet</groupId>
+      <artifactId>openllet-owlapi</artifactId>
+      <version>2.6.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.galigator.openllet</groupId>
+      <artifactId>openllet-explanation</artifactId>
+      <version>2.6.4</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/owlapi/forgetting/kr/KR_AllExplanations.java
+++ b/src/main/java/owlapi/forgetting/kr/KR_AllExplanations.java
@@ -1,0 +1,116 @@
+package owlapi.forgetting.kr;
+
+import openllet.owlapi.OpenlletReasoner;
+import openllet.owlapi.OpenlletReasonerFactory;
+import openllet.owlapi.explanation.PelletExplanation;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.*;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class KR_AllExplanations {
+
+    public static void main(String[] args) throws OWLException, InstantiationException, IllegalAccessException,
+            ClassNotFoundException, IOException {
+        // We first need to obtain a copy of an OWLOntologyManager, which, as the name suggests, manages a set of ontologies.
+        OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+
+        // We load an ontology from the URI specified on the command line
+        @Nonnull
+        String ontologyPath = args[0];
+        String subsumptionPath = args[1];
+
+        System.out.println("Starting Program...");
+        System.out.println("--------------------");
+        System.out.println("Loading ontology located at: " + ontologyPath);
+        System.out.println("");
+
+        // Now load the ontology.
+        File ontologyDocument = new File(ontologyPath);
+        OWLOntology ontology = manager.loadOntologyFromOntologyDocument(ontologyDocument);
+
+        // Report information about the ontology
+        System.out.println("Ontology Loaded!");
+        System.out.println("Format : " + manager.getOntologyFormat(ontology));
+        String parentDir = ontologyDocument.getParent();
+        System.out.println("Parent Directory: " + parentDir);
+
+        // Loading the subsumptions
+        System.out.println("--------------------");
+        System.out.println("Loading subsumptions located at: " + subsumptionPath);
+
+        // READ IN S FROM THE file
+        File subsumptionDocument = new File(subsumptionPath);
+        OWLOntology subsumptions = manager.loadOntologyFromOntologyDocument(subsumptionDocument);
+
+        // Report subsumption ontology
+        System.out.println("Subsumptions Loaded!");
+        System.out.println("Format : " + manager.getOntologyFormat(subsumptions));
+
+        String input1 = args[2].toLowerCase();
+        // FOR EACH AXIOM GET ALL EXPLANATIONS
+        Stream<OWLSubClassOfAxiom> subsumptionList = subsumptions.axioms(AxiomType.SUBCLASS_OF);
+        for (OWLSubClassOfAxiom subsumption : (Iterable<OWLSubClassOfAxiom>) subsumptionList::iterator) {
+            switch (input1) {
+                case "printallexplanations":
+                    getAllExplanations(ontology, subsumption.getSubClass(), subsumption.getSuperClass());
+                    break;
+                case "saveallexplanations":
+                    getAllExplanations(ontology, subsumption.getSubClass(), subsumption.getSuperClass(), parentDir);
+                    break;
+                default:
+            }
+        }
+
+    }
+
+    public static void getAllExplanations(OWLOntology myOntology, OWLClassExpression subClass, OWLClassExpression superClass){
+
+        // Starting up the Pellet Explanation module.
+        PelletExplanation.setup();
+        // Create the reasoner and load the ontology with the open pellet reasoner.
+        OpenlletReasoner reasoner = OpenlletReasonerFactory.getInstance().createReasoner(myOntology);
+
+        // Create an Explanation reasoner with the Pellet Explanation and the Openllet Reasoner modules.
+        PelletExplanation explanationsGenerator = new PelletExplanation(reasoner);
+
+        Set<Set<OWLAxiom>> explanations = explanationsGenerator.getSubClassExplanations(subClass, superClass);
+
+        for(Set<OWLAxiom> Explanation: explanations) {
+            System.out.println("\nExplanation:\n");
+            for (OWLAxiom rule : Explanation) {
+                System.out.println(rule.toString());
+            }
+        }
+
+    }
+
+    public static void getAllExplanations(OWLOntology myOntology, OWLClassExpression subClass,OWLClassExpression superClass, String parentDir) throws IOException {
+        File explanationsFile = new File(parentDir+"/explanation.owl");
+        explanationsFile.createNewFile();
+        FileOutputStream fos = new FileOutputStream(explanationsFile, false);
+
+        // Starting up the Pellet Explanation module.
+        PelletExplanation.setup();
+        // Create the reasoner and load the ontology with the open pellet reasoner.
+        OpenlletReasoner reasoner = OpenlletReasonerFactory.getInstance().createReasoner(myOntology);
+
+        // Create an Explanation reasoner with the Pellet Explanation and the Openllet Reasoner modules.
+        PelletExplanation explanationsGenerator = new PelletExplanation(reasoner);
+
+        Set<Set<OWLAxiom>> explanations = explanationsGenerator.getSubClassExplanations(subClass, superClass);
+
+        for(Set<OWLAxiom> Explanation: explanations) {
+            for (OWLAxiom rule : Explanation) {
+                fos.write(rule.toString().getBytes());
+                fos.write(System.lineSeparator().getBytes());
+            }
+        }
+
+    }
+}

--- a/src/main/java/owlapi/forgetting/kr/KR_Forgetting.java
+++ b/src/main/java/owlapi/forgetting/kr/KR_Forgetting.java
@@ -55,22 +55,6 @@ public class KR_Forgetting {
 				break;
 			default:
 		}
-		// READ IN S FROM THE file
-		OWLOntology ontology2 = manager.loadOntologyFromOntologyDocument(ontologyDocument);
-
-		// FOR EACH AXIOM GET ALL EXPLANATIONS
-		for (final OWLSubClassOfAxiom subsumption : ontology2.getAxioms(AxiomType.SUBCLASS_OF)){
-			String input2 = args[2].toLowerCase();
-			switch (input2) {
-				case "printallexplanations":
-					getAllExplanations(ontology, subsumption.getSubClass(), subsumption.getSuperClass());
-					break;
-				case "saveallexplanations":
-					getAllExplanations(ontology, subsumption.getSubClass(), subsumption.getSuperClass(), parentDir);
-					break;
-				default:
-			}
-		}
 
 	}
 
@@ -102,50 +86,6 @@ public class KR_Forgetting {
 		System.out.println("--------");
 		System.out.println("Done! All subClass statements are saved at file: " + subClassFile);
 		fos.close();
-	}
-
-	public static void getAllExplanations(OWLOntology myOntology, OWLClassExpression subClass,OWLClassExpression superClass){
-
-		// Starting up the Pellet Explanation module.
-		PelletExplanation.setup();
-		// Create the reasoner and load the ontology with the open pellet reasoner.
-		OpenlletReasoner reasoner = OpenlletReasonerFactory.getInstance().createReasoner(myOntology);
-
-		// Create an Explanation reasoner with the Pellet Explanation and the Openllet Reasoner modules.
-		PelletExplanation explanationsGenerator = new PelletExplanation(reasoner);
-
-		Set<Set<OWLAxiom>> explanations = explanationsGenerator.getSubClassExplanations(subClass, superClass);
-
-		for(Set<OWLAxiom> Explanation: explanations) {
-			for (OWLAxiom rule : Explanation) {
-				System.out.println(rule.toString());
-			}
-		}
-
-	}
-
-	public static void getAllExplanations(OWLOntology myOntology, OWLClassExpression subClass,OWLClassExpression superClass, String parentDir) throws IOException {
-		File explanationsFile = new File(parentDir+"/explanation.txt");
-		explanationsFile.createNewFile();
-		FileOutputStream fos = new FileOutputStream(explanationsFile, false);
-
-		// Starting up the Pellet Explanation module.
-		PelletExplanation.setup();
-		// Create the reasoner and load the ontology with the open pellet reasoner.
-		OpenlletReasoner reasoner = OpenlletReasonerFactory.getInstance().createReasoner(myOntology);
-
-		// Create an Explanation reasoner with the Pellet Explanation and the Openllet Reasoner modules.
-		PelletExplanation explanationsGenerator = new PelletExplanation(reasoner);
-
-		Set<Set<OWLAxiom>> explanations = explanationsGenerator.getSubClassExplanations(subClass, superClass);
-
-		for(Set<OWLAxiom> Explanation: explanations) {
-			for (OWLAxiom rule : Explanation) {
-				fos.write(rule.toString().getBytes());
-				fos.write(System.lineSeparator().getBytes());
-			}
-		}
-
 	}
 
 }

--- a/src/main/java/owlapi/forgetting/kr/KR_Forgetting.java
+++ b/src/main/java/owlapi/forgetting/kr/KR_Forgetting.java
@@ -4,27 +4,27 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Set;
+
+import openllet.owlapi.explanation.PelletExplanation;
+import openllet.owlapi.OpenlletReasoner;
+import openllet.owlapi.OpenlletReasonerFactory;
 
 import javax.annotation.Nonnull;
 
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.AxiomType;
-import org.semanticweb.owlapi.model.OWLClass;
-import org.semanticweb.owlapi.model.OWLException;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyManager;
-import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
+import org.semanticweb.owlapi.model.*;
 
 public class KR_Forgetting {
 
 
 	public static void main(String[] args) throws OWLException, InstantiationException, IllegalAccessException,
-	ClassNotFoundException, IOException {
+			ClassNotFoundException, IOException {
 		//String reasonerFactoryClassName = null;
-		
+
 		// We first need to obtain a copy of an OWLOntologyManager, which, as the name suggests, manages a set of ontologies.
 		OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
-		
+
 		// We load an ontology from the URI specified on the command line
 		@Nonnull
 		String ontologyPath = args[0];
@@ -45,48 +45,110 @@ public class KR_Forgetting {
 		System.out.println("Parent Directory: " + parentDir);
 
 		String input1 = args[1].toLowerCase();
-		
+
 		switch(input1) {
-		  case "printallsubclasses":
-			  getAllSubClasses(ontology);
-		    break;
-		  case "saveallsubclasses":
-			  getAllSubClasses(ontology, parentDir);
-		    break;
-		  default:
-			  System.out.println("Please give the program a valid second input");
-		}	
+			case "printallsubclasses":
+				getAllSubClasses(ontology);
+				break;
+			case "saveallsubclasses":
+				getAllSubClasses(ontology, parentDir);
+				break;
+			default:
+		}
+		// READ IN S FROM THE file
+		OWLOntology ontology2 = manager.loadOntologyFromOntologyDocument(ontologyDocument);
+
+		// FOR EACH AXIOM GET ALL EXPLANATIONS
+		for (final OWLSubClassOfAxiom subsumption : ontology2.getAxioms(AxiomType.SUBCLASS_OF)){
+			String input2 = args[2].toLowerCase();
+			switch (input2) {
+				case "printallexplanations":
+					getAllExplanations(ontology, subsumption.getSubClass(), subsumption.getSuperClass());
+					break;
+				case "saveallexplanations":
+					getAllExplanations(ontology, subsumption.getSubClass(), subsumption.getSuperClass(), parentDir);
+					break;
+				default:
+			}
+		}
+
 	}
-	
-	
+
+
 	@SuppressWarnings("deprecation")
 	public static void getAllSubClasses(OWLOntology myOntology) {
-    	for (final OWLSubClassOfAxiom subClass : myOntology.getAxioms(AxiomType.SUBCLASS_OF)){
-    	    if (subClass.getSuperClass() instanceof OWLClass && subClass.getSubClass() instanceof OWLClass){       
-    	    	System.out.println(subClass.getSubClass() + " <http://www.w3.org/2000/01/rdf-schema#subClassOf> " + subClass.getSuperClass());
-    	    }
-    	}
-    }
-	
-	
+		for (final OWLSubClassOfAxiom subClass : myOntology.getAxioms(AxiomType.SUBCLASS_OF)){
+			if (subClass.getSuperClass() instanceof OWLClass && subClass.getSubClass() instanceof OWLClass){
+				System.out.println(subClass.getSubClass() + " <http://www.w3.org/2000/01/rdf-schema#subClassOf> " + subClass.getSuperClass());
+			}
+		}
+	}
+
+
 	@SuppressWarnings("deprecation")
 	public static void getAllSubClasses(OWLOntology myOntology, String parentDir) throws IOException {
 		File subClassFile = new File(parentDir+"/subClasses.nt");
-		subClassFile.createNewFile(); 
-    	FileOutputStream fos = new FileOutputStream(subClassFile, false);   
-    	
+		subClassFile.createNewFile();
+		FileOutputStream fos = new FileOutputStream(subClassFile, false);
+
 		for (final OWLSubClassOfAxiom subClass : myOntology.getAxioms(AxiomType.SUBCLASS_OF)){
-    	    if (subClass.getSuperClass() instanceof OWLClass && subClass.getSubClass() instanceof OWLClass){	
-    	    	String subClassStatement = subClass.getSubClass() + " <http://www.w3.org/2000/01/rdf-schema#subClassOf> " + subClass.getSuperClass() + " .";
-                fos.write(subClassStatement.getBytes());
-                fos.write(System.lineSeparator().getBytes());
-    	    }
-    	}
-		System.out.println("");
+			if (subClass.getSuperClass() instanceof OWLClass && subClass.getSubClass() instanceof OWLClass){
+				String subClassStatement = subClass.getSubClass() + " <http://www.w3.org/2000/01/rdf-schema#subClassOf> " + subClass.getSuperClass() + " .";
+				fos.write(subClassStatement.getBytes());
+				fos.write(System.lineSeparator().getBytes());
+			}
+		}
+		System.out.println("/n");
 		System.out.println("--------");
 		System.out.println("Done! All subClass statements are saved at file: " + subClassFile);
 		fos.close();
-    }
-	
+	}
+
+	public static void getAllExplanations(OWLOntology myOntology, OWLClassExpression subClass,OWLClassExpression superClass){
+
+		// Starting up the Pellet Explanation module.
+		PelletExplanation.setup();
+		// Create the reasoner and load the ontology with the open pellet reasoner.
+		OpenlletReasoner reasoner = OpenlletReasonerFactory.getInstance().createReasoner(myOntology);
+
+		// Create an Explanation reasoner with the Pellet Explanation and the Openllet Reasoner modules.
+		PelletExplanation explanationsGenerator = new PelletExplanation(reasoner);
+
+		Set<Set<OWLAxiom>> explanations = explanationsGenerator.getSubClassExplanations(subClass, superClass);
+
+		for(Set<OWLAxiom> Explanation: explanations) {
+			for (OWLAxiom rule : Explanation) {
+				System.out.println(rule.toString());
+			}
+		}
+
+	}
+
+	public static void getAllExplanations(OWLOntology myOntology, OWLClassExpression subClass,OWLClassExpression superClass, String parentDir) throws IOException {
+		File explanationsFile = new File(parentDir+"/explanation.txt");
+		explanationsFile.createNewFile();
+		FileOutputStream fos = new FileOutputStream(explanationsFile, false);
+
+		// Starting up the Pellet Explanation module.
+		PelletExplanation.setup();
+		// Create the reasoner and load the ontology with the open pellet reasoner.
+		OpenlletReasoner reasoner = OpenlletReasonerFactory.getInstance().createReasoner(myOntology);
+
+		// Create an Explanation reasoner with the Pellet Explanation and the Openllet Reasoner modules.
+		PelletExplanation explanationsGenerator = new PelletExplanation(reasoner);
+
+		Set<Set<OWLAxiom>> explanations = explanationsGenerator.getSubClassExplanations(subClass, superClass);
+
+		for(Set<OWLAxiom> Explanation: explanations) {
+			for (OWLAxiom rule : Explanation) {
+				fos.write(rule.toString().getBytes());
+				fos.write(System.lineSeparator().getBytes());
+			}
+		}
+
+	}
 
 }
+
+
+

--- a/testCase/ore_ont_338.owl
+++ b/testCase/ore_ont_338.owl
@@ -1,0 +1,14 @@
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://owl.cs.man.ac.uk/dlapproximated/353f96b3-1adc-446a-9dca-59f4af695e0a_2.0draftB.rdfs.owl.xml>
+Declaration(Class(<file:/media/owl/Seagate%20Expansion%20Drive/mowlcorp_rep/mowlcorp_2014.10.07_orig/files/E72_Legal_Object>))
+Declaration(Class(<file:/media/owl/Seagate%20Expansion%20Drive/mowlcorp_rep/mowlcorp_2014.10.07_orig/files/F3_Manifestation_Product_Type>))
+Declaration(Class(<file:test>))
+SubClassOf(<file:/media/owl/Seagate%20Expansion%20Drive/mowlcorp_rep/mowlcorp_2014.10.07_orig/files/F3_Manifestation_Product_Type> <file:test>)
+SubClassOf(<file:test> <file:/media/owl/Seagate%20Expansion%20Drive/mowlcorp_rep/mowlcorp_2014.10.07_orig/files/E72_Legal_Object>)
+)

--- a/testCase/subClasses.nt
+++ b/testCase/subClasses.nt
@@ -1,0 +1,1 @@
+<file:/media/owl/Seagate%20Expansion%20Drive/mowlcorp_rep/mowlcorp_2014.10.07_orig/files/F3_Manifestation_Product_Type> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <file:/media/owl/Seagate%20Expansion%20Drive/mowlcorp_rep/mowlcorp_2014.10.07_orig/files/E72_Legal_Object> .


### PR DESCRIPTION
I've added in a separate function package that can generate explanations from a list of subClasses. At the moment this is based on a file that contains the to explain relations. To use this function on the command line the user needs to specify the ontology location, the location of the Rule that needs to be explained, and if the user wants it printed to the screen or to a file. 

```
owlapi.forgetting.kr.KR_AllExplanations D:\Users\Thomas\Documents\testCases\ore_ont_338.owl \
D:\Users\Thomas\Documents\testCases\subClasses.nt printallexplanations
```

I did need to upgrade the java version from 7 to 8 to get the streams working correctly. But It should also be possible to write this without a stream. I've also added in a few packages.

Finally, I've added in a folder in which I've added a testcase. But maybe we will need a few more?

